### PR TITLE
feat(ISSUE-2): Add secure flag (no_env) to pass secrets as args instead of env

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,15 @@ env_file: '.env'
 secret_name: <your_secret>
 vault: aws
 ```
+This default configuration will inject fetched secrets into `os.environ` of main process. If your app instead want to receive secrets as STDIN arguments, use `no_env: true` field.
+This is a secure way than default control but app now should parse arguments itself.
+
+```yaml
+env_file: '.env'
+secret_name: <your_secret>
+vault: aws
+no_env: true # Setting true will send KEY1=VAL1 secret pairs as command args
+```
 
 ## Setting Up Your Injectable Secrets
 

--- a/src/whispr/__about__.py
+++ b/src/whispr/__about__.py
@@ -1,1 +1,1 @@
-version = "0.1.1"
+version = "0.2.0"

--- a/src/whispr/cli.py
+++ b/src/whispr/cli.py
@@ -65,10 +65,9 @@ def run(command):
         return
 
     filled_env_vars = get_filled_secrets(env_file, vault_secrets)
-    os.environ.update(filled_env_vars)
-    logger.info("Secrets have been successfully injected into the environment")
 
-    execute_command(command)
+    no_env = config.get("no_env")
+    execute_command(command, no_env, filled_env_vars)
 
 
 cli.add_command(init)


### PR DESCRIPTION
## Description

The current mode only supports passing secrets fetched as environment variables. There is another secure way to pass secrets & sensitive info via STDIN args.

```yml
env_file: .env
secret_name: nyell-db-creds
vault: aws
no_env: true
```

and this will use ARGS instead of environment. This is much secure way. 