### PR TITLE
feat: add support for AWS SSO profile in config

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,4 +1,4 @@
-name: Semgrep CI Scan
+name: Run security scan
 
 on:
   push:
@@ -6,7 +6,7 @@ on:
       - main
   pull_request:
     branches:
-      - '*'
+      - "*"
 
 jobs:
   semgrep-scan:
@@ -19,7 +19,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: '3.10'
+          python-version: "3.10"
 
       - name: Install Semgrep
         run: |

--- a/clean_build.sh
+++ b/clean_build.sh
@@ -1,0 +1,4 @@
+rm -rf dist
+pip uninstall -q --exists-action=w whispr
+hatch build
+pip install -q dist/whispr-0.3.0-py3-none-any.whl

--- a/src/whispr/__about__.py
+++ b/src/whispr/__about__.py
@@ -1,1 +1,1 @@
-version = "0.3.0"
+version = "0.4.0"

--- a/src/whispr/cli.py
+++ b/src/whispr/cli.py
@@ -11,25 +11,25 @@ from whispr.utils.io import (
 )
 from whispr.utils.process import execute_command
 
-from whispr.utils.vault import (
-    fetch_secrets,
-    get_filled_secrets,
-    prepare_vault_config
-)
+from whispr.utils.vault import fetch_secrets, get_filled_secrets, prepare_vault_config
 
 CONFIG_FILE = "whispr.yaml"
 
 
 @click.group()
 def cli():
-    """Click group"""
+    """Whispr is a CLI tool to safely inject vault secrets into an application.
+    Run `whispr init vault` to create a configuration.
+
+    Availble values for vault: ["aws", "azure", "gcp"]
+    """
     pass
 
 
 @click.command()
 @click.argument("vault", nargs=1, type=click.STRING)
 def init(vault):
-    """Creates a whispr configuration file"""
+    """Creates a whispr vault configuration file (YAML). This file defines vault properties like secret name and vault type etc."""
     config = prepare_vault_config(vault)
     write_to_yaml_file(config, CONFIG_FILE)
 
@@ -37,7 +37,9 @@ def init(vault):
 @click.command()
 @click.argument("command", nargs=-1, type=click.UNPROCESSED)
 def run(command):
-    """Fetches secrets and injects them into the environment."""
+    """Runs a command by injecting secrets fetched from vault via environment or list of command arguments.
+    Examples: [whispr run 'python main.py', whispr run 'bash script.sh']
+    """
     if not os.path.exists(CONFIG_FILE):
         logger.error("whispr configuration file not found. Run 'whispr init' first.")
         return

--- a/src/whispr/factory.py
+++ b/src/whispr/factory.py
@@ -1,7 +1,5 @@
 """Vault factory"""
 
-import os
-
 import boto3
 import botocore.exceptions
 import structlog
@@ -22,7 +20,7 @@ class VaultFactory:
     @staticmethod
     def get_vault(**kwargs) -> SimpleVault:
         """
-        Factory method to return the appropriate secret manager based on the vault type.
+        Factory method to return the appropriate secrets manager client based on the vault type.
 
         :param vault_type: The type of the vault ('aws', 'azure', 'gcp').
         :param logger: Structlog logger instance.

--- a/src/whispr/utils/io.py
+++ b/src/whispr/utils/io.py
@@ -4,12 +4,14 @@ import yaml
 
 from whispr.logging import logger
 
+
 def write_to_yaml_file(config: dict, file_path: str):
     """Writes a given config object to a file in YAML format"""
     if not os.path.exists(file_path):
         with open(file_path, "w", encoding="utf-8") as file:
             yaml.dump(config, file)
         logger.info(f"{file_path} has been created.")
+
 
 def load_config(file_path: str) -> dict:
     """Loads a given config file"""

--- a/src/whispr/utils/process.py
+++ b/src/whispr/utils/process.py
@@ -4,9 +4,10 @@ import shlex
 
 from whispr.logging import logger
 
+
 def execute_command(command: tuple, no_env: bool, secrets: dict):
     """Executes a Unix/Windows command.
-       Arg: `no_env` decides whether secrets are passed vai environment or K:V pairs in command arguments.
+    Arg: `no_env` decides whether secrets are passed vai environment or K:V pairs in command arguments.
     """
     if not secrets:
         secrets = {}
@@ -16,9 +17,7 @@ def execute_command(command: tuple, no_env: bool, secrets: dict):
 
         if no_env:
             # Pass as --env K=V format (secure)
-            usr_command.extend([
-                f"{k}={v}" for k,v in secrets.items()
-            ])
+            usr_command.extend([f"{k}={v}" for k, v in secrets.items()])
         else:
             # Pass via environment (slightly insecure)
             os.environ.update(secrets)

--- a/tests/test_aws.py
+++ b/tests/test_aws.py
@@ -1,12 +1,10 @@
 """Tests for AWS module"""
 
 import unittest
-from unittest.mock import Mock, MagicMock, patch
+from unittest.mock import MagicMock, patch
 
 import botocore.exceptions
-import structlog
 
-from whispr.vault import SimpleVault
 from whispr.aws import AWSVault
 
 

--- a/tests/test_factory.py
+++ b/tests/test_factory.py
@@ -83,7 +83,8 @@ class FactoryTestCase(unittest.TestCase):
         with self.assertRaises(ValueError):
             VaultFactory.get_vault(**config)
 
-    def test_get_gcp_vault_client(self):
+    @patch("google.cloud.secretmanager.SecretManagerServiceClient")
+    def test_get_gcp_vault_client(self, mock_client):
         """Test GCPVault client"""
         config = {
             "vault": "gcp",
@@ -94,6 +95,7 @@ class FactoryTestCase(unittest.TestCase):
         }
         vault_instance = VaultFactory.get_vault(**config)
         self.assertIsInstance(vault_instance, GCPVault)
+        mock_client.assert_called_once()
 
     def test_get_gcp_vault_client_no_project_id(self):
         """Test GCPVault raises exception when project_id is not defined in config"""

--- a/tests/test_factory.py
+++ b/tests/test_factory.py
@@ -1,0 +1,105 @@
+import unittest
+from unittest.mock import MagicMock, patch
+
+import botocore.exceptions
+
+from whispr.aws import AWSVault
+from whispr.azure import AzureVault
+from whispr.gcp import GCPVault
+
+from whispr.factory import VaultFactory
+
+
+class FactoryTestCase(unittest.TestCase):
+    """Unit tests for Factory method to create vaults"""
+
+    def setUp(self):
+        """Set up mocks for logger, GCP client, and project_id before each test."""
+        self.mock_logger = MagicMock()
+
+    def test_get_aws_vault_simple_client(self):
+        """Test AWSVault client without SSO"""
+        config = {
+            "vault": "aws",
+            "env": ".env",
+            "secret_name": "dummy_secret",
+            "logger": self.mock_logger,
+        }
+        vault_instance = VaultFactory.get_vault(**config)
+        self.assertIsInstance(vault_instance, AWSVault)
+
+    @patch("boto3.Session")
+    def test_get_aws_vault_sso_client(self, mock_session):
+        """Test AWSVault SSO session client"""
+        config = {
+            "vault": "aws",
+            "env": ".env",
+            "secret_name": "dummy_secret",
+            "sso_profile": "dev",
+            "logger": self.mock_logger,
+        }
+        vault_instance = VaultFactory.get_vault(**config)
+        self.assertIsInstance(vault_instance, AWSVault)
+        mock_session.assert_called_with(profile_name="dev")
+
+    @patch("boto3.Session")
+    def test_get_aws_vault_sso_client_profile_not_found(self, mock_session):
+        """Test AWSVault raises exception when sso_profile is defined but not found in AWS config"""
+        config = {
+            "vault": "aws",
+            "env": ".env",
+            "secret_name": "dummy_secret",
+            "sso_profile": "dev",
+            "logger": self.mock_logger,
+        }
+        mock_session.side_effect = botocore.exceptions.ProfileNotFound(profile="dev")
+        with self.assertRaises(ValueError):
+            VaultFactory.get_vault(**config)
+
+    def test_get_azure_vault_client(self):
+        """Test AzureVault client"""
+        config = {
+            "vault": "azure",
+            "env": ".env",
+            "secret_name": "dummy_secret",
+            "vault_url": "https://example.org",
+            "logger": self.mock_logger,
+        }
+        vault_instance = VaultFactory.get_vault(**config)
+        self.assertIsInstance(vault_instance, AzureVault)
+
+    def test_get_azure_vault_client_no_url(self):
+        """Test AzureVault raises exception when vault_url is not defined in config"""
+        config = {
+            "vault": "azure",
+            "env": ".env",
+            "secret_name": "dummy_secret",
+            "logger": self.mock_logger,
+        }
+
+        with self.assertRaises(ValueError):
+            VaultFactory.get_vault(**config)
+
+    def test_get_gcp_vault_client(self):
+        """Test GCPVault client"""
+        config = {
+            "vault": "gcp",
+            "env": ".env",
+            "secret_name": "dummy_secret",
+            "project_id": "dummy_project",
+            "logger": self.mock_logger,
+        }
+        vault_instance = VaultFactory.get_vault(**config)
+        self.assertIsInstance(vault_instance, GCPVault)
+
+    def test_get_gcp_vault_client_no_project_id(self):
+        """Test GCPVault raises exception when project_id is not defined in config"""
+        config = {
+            "vault": "gcp",
+            "env": ".env",
+            "secret_name": "dummy_secret",
+            "logger": self.mock_logger,
+        }
+
+        with self.assertRaises(ValueError):
+            VaultFactory.get_vault(**config)

--- a/tests/test_factory.py
+++ b/tests/test_factory.py
@@ -1,3 +1,4 @@
+import os
 import unittest
 from unittest.mock import MagicMock, patch
 
@@ -16,6 +17,7 @@ class FactoryTestCase(unittest.TestCase):
     def setUp(self):
         """Set up mocks for logger, GCP client, and project_id before each test."""
         self.mock_logger = MagicMock()
+        os.environ["AWS_DEFAULT_REGION"] = "us-west-2"
 
     def test_get_aws_vault_simple_client(self):
         """Test AWSVault client without SSO"""
@@ -52,6 +54,7 @@ class FactoryTestCase(unittest.TestCase):
             "sso_profile": "dev",
             "logger": self.mock_logger,
         }
+
         mock_session.side_effect = botocore.exceptions.ProfileNotFound(profile="dev")
         with self.assertRaises(ValueError):
             VaultFactory.get_vault(**config)

--- a/tests/test_gcp.py
+++ b/tests/test_gcp.py
@@ -1,12 +1,10 @@
 """Tests for GCP module"""
 
 import unittest
-from unittest.mock import Mock, patch, MagicMock
+from unittest.mock import MagicMock
 
 import google.api_core.exceptions
-import structlog
 
-from whispr.vault import SimpleVault
 from whispr.gcp import GCPVault
 
 

--- a/tests/test_io_utils.py
+++ b/tests/test_io_utils.py
@@ -1,10 +1,10 @@
-
 import os
 import yaml
 import unittest
 
 from unittest.mock import MagicMock, patch, mock_open
 from whispr.utils.io import write_to_yaml_file, load_config
+
 
 class IOUtilsTestCase(unittest.TestCase):
     """Unit tests for the file utilities: write_to_yaml_file and load_config."""
@@ -18,7 +18,9 @@ class IOUtilsTestCase(unittest.TestCase):
     @patch("whispr.utils.io.logger", new_callable=lambda: MagicMock())
     @patch("builtins.open", new_callable=mock_open)
     @patch("os.path.exists", return_value=False)
-    def test_write_to_yaml_file_creates_file(self, mock_exists, mock_open_file, mock_logger):
+    def test_write_to_yaml_file_creates_file(
+        self, mock_exists, mock_open_file, mock_logger
+    ):
         """Test that write_to_yaml_file creates a new file and writes config data as YAML."""
         write_to_yaml_file(self.config, self.file_path)
 
@@ -29,7 +31,9 @@ class IOUtilsTestCase(unittest.TestCase):
     @patch("whispr.utils.io.logger", new_callable=lambda: MagicMock())
     @patch("builtins.open", new_callable=mock_open)
     @patch("os.path.exists", return_value=True)
-    def test_write_to_yaml_file_does_not_overwrite_existing_file(self, mock_exists, mock_open_file, mock_logger):
+    def test_write_to_yaml_file_does_not_overwrite_existing_file(
+        self, mock_exists, mock_open_file, mock_logger
+    ):
         """Test that write_to_yaml_file does not overwrite an existing file."""
         write_to_yaml_file(self.config, self.file_path)
 

--- a/tests/test_process_utils.py
+++ b/tests/test_process_utils.py
@@ -23,22 +23,30 @@ class ProcessUtilsTestCase(unittest.TestCase):
         execute_command(self.command, self.no_env, self.secrets)
 
         expected_command = ["echo", "Hello", "API_KEY=123456"]
-        mock_subprocess_run.assert_called_once_with(expected_command, env=os.environ, shell=False, check=True)
+        mock_subprocess_run.assert_called_once_with(
+            expected_command, env=os.environ, shell=False, check=True
+        )
 
     @patch("whispr.utils.process.logger", new_callable=lambda: MagicMock())
     @patch("subprocess.run")
     @patch("os.environ.update")
-    def test_execute_command_with_env(self, mock_env_update, mock_subprocess_run, mock_logger):
+    def test_execute_command_with_env(
+        self, mock_env_update, mock_subprocess_run, mock_logger
+    ):
         """Test execute_command with `no_env=False`, passing secrets via environment variables."""
         execute_command(self.command, no_env=False, secrets=self.secrets)
 
         mock_env_update.assert_called_once_with(self.secrets)
         expected_command = ["echo", "Hello"]
-        mock_subprocess_run.assert_called_once_with(expected_command, env=os.environ, shell=False, check=True)
+        mock_subprocess_run.assert_called_once_with(
+            expected_command, env=os.environ, shell=False, check=True
+        )
 
     @patch("whispr.utils.process.logger", new_callable=lambda: MagicMock())
     @patch("subprocess.run", side_effect=subprocess.CalledProcessError(1, "test"))
-    def test_execute_command_called_process_error(self, mock_subprocess_run, mock_logger):
+    def test_execute_command_called_process_error(
+        self, mock_subprocess_run, mock_logger
+    ):
         """Test execute_command handles CalledProcessError and logs an error message."""
         with self.assertRaises(subprocess.CalledProcessError):
             execute_command(self.command, no_env=True, secrets=self.secrets)
@@ -54,5 +62,7 @@ class ProcessUtilsTestCase(unittest.TestCase):
         execute_command(self.command, no_env=True, secrets={})
 
         expected_command = ["echo", "Hello"]
-        mock_subprocess_run.assert_called_once_with(expected_command, env=os.environ, shell=False, check=True)
+        mock_subprocess_run.assert_called_once_with(
+            expected_command, env=os.environ, shell=False, check=True
+        )
         mock_logger.error.assert_not_called()

--- a/tests/test_vault_utils.py
+++ b/tests/test_vault_utils.py
@@ -43,18 +43,28 @@ class SecretUtilsTestCase(unittest.TestCase):
         )
 
     @patch("whispr.utils.vault.logger", new_callable=lambda: MagicMock())
-    @patch("whispr.utils.vault.VaultFactory.get_vault", side_effect=ValueError("Invalid vault type"))
+    @patch(
+        "whispr.utils.vault.VaultFactory.get_vault",
+        side_effect=ValueError("Invalid vault type"),
+    )
     def test_fetch_secrets_invalid_vault(self, mock_get_vault, mock_logger):
         """Test fetch_secrets logs an error if the vault factory raises a ValueError."""
-        result = fetch_secrets({
-            "vault": "UNKOWN",
-            "secret_name": "test_secret",
-        })
+        result = fetch_secrets(
+            {
+                "vault": "UNKOWN",
+                "secret_name": "test_secret",
+            }
+        )
 
         self.assertEqual(result, {})
-        mock_logger.error.assert_called_once_with("Error creating vault instance: Invalid vault type")
+        mock_logger.error.assert_called_once_with(
+            "Error creating vault instance: Invalid vault type"
+        )
 
-    @patch("whispr.utils.vault.dotenv_values", return_value={"API_KEY": "", "OTHER_KEY": ""})
+    @patch(
+        "whispr.utils.vault.dotenv_values",
+        return_value={"API_KEY": "", "OTHER_KEY": ""},
+    )
     @patch("whispr.utils.vault.logger", new_callable=lambda: MagicMock())
     def test_get_filled_secrets_partial_match(self, mock_logger, mock_dotenv_values):
         """Test get_filled_secrets fills only matching secrets from vault_secrets."""


### PR DESCRIPTION
## Description

This PR adds support for AWS SSO profiles. Just set the below key in Whispr config:

```yaml
vault: aws
sso_profile: dev
```

Where `dev` is the SSO profile name used to sign into AWS.

## Changes

- Add AWS SSO Profile support
- Improve Whispr CLI commands help messages
- Add a clean_build script for local package build and test